### PR TITLE
Apply more backouts for auto-injection

### DIFF
--- a/pkg/instrumentation/auto/monitor.go
+++ b/pkg/instrumentation/auto/monitor.go
@@ -26,7 +26,47 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
 )
 
-var excludedNamespaces = []string{"kube-system", "amazon-cloudwatch"}
+var excludedNamespaces = []string{
+	// --- Monitoring & Observability ---
+	"monitoring",                    // Prometheus, kube-prometheus-stack, Grafana
+	"loki",                          // Loki, Promtail
+	"observability",                 // Tempo, Jaeger
+	"opentelemetry-operator-system", // OpenTelemetry Collector / Operator
+	"tracing",                       // Zipkin or similar tracing tools
+
+	// --- Ingress & Networking ---
+	"ingress-nginx", // NGINX Ingress Controller
+	"traefik",       // Traefik Ingress Controller
+	"istio-system",  // Istio control plane
+	"linkerd",       // Linkerd service mesh
+	"cert-manager",  // Cert-Manager for TLS certificates
+	"external-dns",  // ExternalDNS controller
+
+	// --- Cloud Integrations ---
+	"aws-load-balancer-controller", // AWS Load Balancer Controller
+	"kube-system",                  // Cluster Autoscaler, CSI Drivers, Metrics Server
+	"external-dns",                 // ExternalDNS (sometimes deployed here too)
+
+	// --- Security & Policy ---
+	"kyverno",           // Kyverno policy engine
+	"gatekeeper-system", // OPA Gatekeeper
+	"falco",             // Falco runtime security
+	"vault",             // HashiCorp Vault for secrets
+
+	// --- CI/CD & Management ---
+	"argocd",           // Argo CD
+	"flux-system",      // Flux CD
+	"jenkins",          // Jenkins CI/CD
+	"tekton-pipelines", // Tekton pipelines
+	"spinnaker",        // Spinnaker
+	"harbor",           // Harbor container registry
+	"reloader",         // Reloader for configmap/secret reloads
+
+	// --- Other Utilities ---
+	"keda",   // KEDA event-driven autoscaler
+	"velero", // Velero backup/restore
+	"minio",  // MinIO object storage
+}
 
 const (
 	ByLabel              = "IndexByLabel"


### PR DESCRIPTION
1. Disable auto-monitor when `instrumentation.opentelemetry.io` CRD is installed. No additional RBAC rule is required.
2. Disable auto-monitor when an OTEL collector container is found.
3. Disable auto-monitor in commonly used third party components.